### PR TITLE
Bug Fix on PRS Decompression Algorithm

### DIFF
--- a/src/prs.js
+++ b/src/prs.js
@@ -31,23 +31,20 @@ export function decompress(buffer) {
         break;
       }
       size = offset & 7;
-      offset = (offset >> 3) - 8192;
+      offset = (offset >> 3) | -0x2000;
       if (size === 0) {
         let num3 = readCursor.readUint8();
         size = num3 + 10;
       } else {
         size += 2;
       }
-
-      offset |= 0xFFFFFFFFFFFFE000;
     } else {
       // short copy
       flag = readCursor.readBit() ? 1 : 0;
       size = readCursor.readBit() ? 1 : 0;
       size = (size | (flag << 1)) + 2;
 
-      offset = readCursor.readInt8();
-      if (offset > 0) offset = -offset;
+      offset = readCursor.readInt8() | -0x100;
     }
 
     // do the actual copy


### PR DESCRIPTION
- Fixed bug causing incorrect decompression of compressed input data. This bug could be easily observed on large (for instance, 200 layers) compressed files (i.e.: flag at position 0x3 = 0x84) generated by PSO2, the original source of .sar files. Faulty decompression would lead to various distortions in the output such as coloring symbols with incorrect colors, breaking the "parallelogram rule of symbol art" (i.e.: every symbol must be a parallelogram), breaking the symbol sizing limits (yes, there is a limit to how big they can be), breaking symbol position limits (places off-canvas), and maybe more.
- Testing was done using my SA image editor engine to verify visual correctness of Symbol Art as well as data correctness. It took a good few hours to figure out why non-compressed displayed correctly but compressed ones had weird things going on.
This simple fix will ensure correctness of the algorithm.