### PR TITLE
Bug Fix on Parsing Symbol Art Name

### DIFF
--- a/src/sarstruct.js
+++ b/src/sarstruct.js
@@ -54,7 +54,9 @@ export const schema = (cursor, registry) => {
   }
 
   let name = [];
-  for (let i = 0; i < 13; i++) {
+  // Read rest of buffer into Symbol Art name
+  let startPos = cursor.pos;
+  for (let i = 0; i < (cursor.dataView.byteLength - startPos) / 2; i++) {
     try {
       let c = struct.parseWithCursor(cursor, 'u16le', registry);
       name.push(c);


### PR DESCRIPTION
- Fixed bug caused by hard-coded name string size (=13). Parsing now reads the buffer until the end and interprets that whole remaining bit stream as a little-endian 16 bit character sequence.